### PR TITLE
Using C++17 to support shared_timed_mutex as used in godot 3.3-stable

### DIFF
--- a/gameanalytics/SCsub
+++ b/gameanalytics/SCsub
@@ -6,7 +6,7 @@ sources = [
 ]
 
 module_env = env.Clone()
-module_env.Append(CXXFLAGS=['-std=c++11'])
+module_env.Append(CXXFLAGS=['-std=c++17'])
 
 if env['platform'] == 'iphone':
     sources.append("ios/src/GameAnalyticsCpp.mm")

--- a/gameanalytics/SCsub
+++ b/gameanalytics/SCsub
@@ -6,7 +6,6 @@ sources = [
 ]
 
 module_env = env.Clone()
-module_env.Append(CXXFLAGS=['-std=c++17'])
 
 if env['platform'] == 'iphone':
     sources.append("ios/src/GameAnalyticsCpp.mm")


### PR DESCRIPTION
Some of the C++ idioms in Godot have been modernized in [3.3-stable](https://github.com/godotengine/godot/releases/tag/3.3-stable). This supports building the plugin from this branch.

Previously, it would fail in this fashion: 
```
In file included from modules/gameanalytics/register_types.cpp:2:
In file included from ./core/class_db.h:34:
In file included from ./core/method_bind.h:35:
In file included from ./core/method_ptrcall.h:34:
In file included from ./core/math/transform_2d.h:35:
In file included from ./core/pool_vector.h:37:
./core/os/rw_lock.h:41:15: error: no type named 'shared_timed_mutex' in
      namespace 'std'
        mutable std::shared_timed_mutex mutex;
                ~~~~~^
```