### PR TITLE
Fixes multiple singleton creation error on Godot .Net builds.

### DIFF
--- a/gameanalytics/register_types.cpp
+++ b/gameanalytics/register_types.cpp
@@ -7,12 +7,16 @@ static GameAnalytics* GAPtr = NULL;
 
 void initialize_gameanalytics_module(ModuleInitializationLevel p_level)
 {
-    ClassDB::register_class<GameAnalytics>();
-    GAPtr = memnew(GameAnalytics);
-    Engine::get_singleton()->add_singleton(Engine::Singleton("GameAnalytics", GameAnalytics::get_singleton()));
+    if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+        ClassDB::register_class<GameAnalytics>();
+        GAPtr = memnew(GameAnalytics);
+        Engine::get_singleton()->add_singleton(Engine::Singleton("GameAnalytics", GameAnalytics::get_singleton()));
+    }
 }
 
 void uninitialize_gameanalytics_module(ModuleInitializationLevel p_level)
 {
-    memdelete(GAPtr);
+    if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+        memdelete(GAPtr);
+    }
 }


### PR DESCRIPTION
In Godot 4.x .Net builds, the current process launches multiple phases, this check needs to be added to have the GA module work with .Net builds.
(Some issues remain with the builds though, but with this I currently do have GA working in the Godot Editor on macOS)

Side note: Please tell someone to change the name of Godot on your web site, on some occasions it says GoDot which is incorrect and cringe.