### PR TITLE
Fix resource item types configuration method

### DIFF
--- a/src/gameanalytics/GameAnalytics.cpp
+++ b/src/gameanalytics/GameAnalytics.cpp
@@ -118,7 +118,7 @@ void GameAnalytics::configureAvailableResourceItemTypes(const PackedStringArray 
 {
     if(_impl)
     {
-        return _impl->SetAvailableResourceCurrencies(ToStringVector(types));
+        return _impl->SetAvailableResourceItemTypes(ToStringVector(types));
     }
 }
 


### PR DESCRIPTION
`configureAvailableResourceItemTypes` was calling ther wrong impl, resulting in both `configureAvailableResourceItemTypes` and `configureAvailableResourceCurrencies` doing the same call, which, in the end, created a bug where item types are never considered as registered.