### PR TITLE
Post releases to Slack (#public-sdk-releases)

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -59,3 +59,15 @@ jobs:
           generate_release_notes: true
           make_latest: true
           files: GameAnalytics-Godot-${{ inputs.tag_name }}.zip
+
+
+  notify:
+    name: Slack notification
+    needs: release
+    uses: GameAnalytics/sdk-release-notify/.github/workflows/notify.yml@main
+    with:
+      sdk_name: Godot SDK
+      tag: ${{ inputs.tag_name }}
+      releaser: ${{ github.actor }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack-release-notify.yml
+++ b/.github/workflows/slack-release-notify.yml
@@ -1,0 +1,32 @@
+# Posts every published release of this repo to Slack (#public-sdk-releases).
+# Logic lives in GameAnalytics/sdk-release-notify; this file only names the SDK.
+#
+# To re-post an existing release (pilot, or Slack was down): Actions tab →
+# "Slack release notification" → Run workflow → enter the tag.
+
+name: Slack release notification
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to (re)post, e.g. 1.2.3
+        required: true
+        type: string
+
+jobs:
+  notify:
+    # Skip pre-releases, and skip releases created by a bot: repos whose
+    # releases are cut by a workflow post from that workflow instead, so the
+    # real person can be credited.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.release.prerelease && !endsWith(github.event.release.author.login, '[bot]'))
+    uses: GameAnalytics/sdk-release-notify/.github/workflows/notify.yml@main
+    with:
+      sdk_name: Godot SDK
+      tag: ${{ inputs.tag }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Adds `.github/workflows/slack-release-notify.yml`: every published GitHub Release of this repo is posted to Slack `#public-sdk-releases` with the SDK name (**Godot SDK**), version, releaser and release notes.

The logic lives in [GameAnalytics/sdk-release-notify](https://github.com/GameAnalytics/sdk-release-notify); this file only names the SDK. Pre-releases are skipped. A manual *Run workflow* with an existing tag re-posts that release.

Also adds a `notify` job to `create_release.yml` so releases created by the workflow credit the person who triggered it instead of `github-actions[bot]`. The new workflow skips bot-authored releases, so nothing posts twice.
**Before merging**: the org secret `SLACK_WEBHOOK_URL` must include this repository.